### PR TITLE
Support for custom dialog content

### DIFF
--- a/javafx-dialogs/test/javafx/scene/control/DialogsTest.java
+++ b/javafx-dialogs/test/javafx/scene/control/DialogsTest.java
@@ -1,13 +1,17 @@
 package javafx.scene.control;
 
+
 import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
 
 import javafx.application.Application;
+import javafx.geometry.Insets;
 import javafx.scene.control.Dialogs.DialogOptions;
 import javafx.scene.control.Dialogs.DialogResponse;
+import javafx.scene.layout.GridPane;
 import javafx.stage.Stage;
+import javafx.util.Callback;
 
 /**
  * Just some simple tests. I didn't want to use a testing framework for this.
@@ -26,8 +30,10 @@ public class DialogsTest extends Application {
 		showConfirmDialogWithOptions(primaryStage);
 		showInputDialog(primaryStage);
 		showInputDialogWithChoices(primaryStage);
+		showCustomDialog(primaryStage);
 	}
 	
+
 	private void showInformationDialog(Stage stage) {
 		Dialogs.showInformationDialog(stage, "I have a great message for you!", "Information Dialog", "title");
 	}
@@ -71,6 +77,43 @@ public class DialogsTest extends Application {
 		System.out.println("InputDialog Result: " + input);
 	}
 	
+	private class Credentials {
+		private String username; private String password;
+		public Credentials(String username, String password) {
+			this.username = username; this.password = password;
+		}
+		@Override
+		public String toString() {
+			return "Credentials(" + username + "/" + password + ")";
+		}
+	}
+	private Credentials credentials;
+	
+	private void showCustomDialog(Stage stage) {
+		GridPane grid = new GridPane();
+		grid.setHgap(10);
+	    grid.setVgap(10);
+	    grid.setPadding(new Insets(0, 10, 0, 10));
+		final TextField username = new TextField(); username.setPromptText("Username");
+		final PasswordField password = new PasswordField(); password.setPromptText("Password");
+
+		grid.add(new Label("Username:"), 0, 0);
+		grid.add(username, 1, 0);
+		grid.add(new Label("Password:"), 0, 1);
+		grid.add(password, 1, 1);
+		Callback<Void, Void> myCallback = new Callback<Void, Void>() {
+			@Override
+			public Void call(Void param) {
+				credentials = new Credentials(username.getText(), password.getText());
+				return null;
+			}
+		};
+				
+		DialogResponse resp = Dialogs.showCustomDialog(stage, grid, "Please log in", "Login", DialogOptions.OK_CANCEL, myCallback);
+		System.out.println("Custom Dialog: User clicked: " + resp);
+		//You must check the resp, since input fields' texts are returned regardless of what button was pressed. (ie. If user clicked 'Cancel' disregard the input) 
+		System.out.println("Custom Dialog: Field 'credentials' set from custom dialog: " + credentials);
+	}
 
 	public static void main(String[] args) {
 		launch(args);


### PR DESCRIPTION
Quick hack to support custom dialog content.
Example added in DialogTest.
![login_dialog](https://f.cloud.github.com/assets/2960714/422476/ca11c414-ad28-11e2-8c67-46369b443823.png)
